### PR TITLE
allowMismatch bug fix

### DIFF
--- a/jquery.flexselect.js
+++ b/jquery.flexselect.js
@@ -312,7 +312,7 @@
         this.setValue(selected.value);
         this.picked = true;
       } else if (this.settings.allowMismatch) {
-        this.setValue.val("");
+        this.setValue("");
       } else {
         this.reset();
       }


### PR DESCRIPTION
Line 315:
Change setValue.val(""); to setValue(""); This will now set original
`select`'s value to blank as intended. Previously this would have no
effect and instead kept previously selected values.
Fixes issues #13 and #37.